### PR TITLE
Update PangolinMQTT.cpp

### DIFF
--- a/src/PangolinMQTT.cpp
+++ b/src/PangolinMQTT.cpp
@@ -135,7 +135,7 @@ void PangolinMQTT::_handlePacket(mb m){
             else {
                 PANGO::_space=PANGO::TCP->space();
                 bool session=i[0] & 0x01;
-                Serial.printf("\nSESSION IS %s\n",session ? "DIRTY":"CLEAN");
+                //Serial.printf("\nSESSION IS %s\n",session ? "DIRTY":"CLEAN");
                 Packet::_resendPartialTxns();
                 PANGO_PRINT("CONNECTED FH=%u SH=%u\n",PANGO::_HAL_getFreeHeap(),getMaxPayloadSize());
                 if(_cbConnect) _cbConnect(session);


### PR DESCRIPTION
Comment out Serial object print.  ? change it to PANGO_PRINT
I note https://github.com/philbowles/PangolinMQTT/issues/8

Is there a reason that the https://github.com/philbowles/PangolinMQTT/blob/300d2b38689f66db6344da2488ea429116555ef5/src/PANGO.cpp#L204

Could also not be changed to 

```cpp
void PANGO::dumphex(Print & output, uint8_t* mem, size_t len,uint8_t W) 
```

and forgo any dependance on `Serial` all together.  I also do not have a Serial Object for most of my projects and output debugging over a telnet interface.  I also use the Serial interface for communication with other devices, ie PJON so printing to it corrupts that communication.  I can of course comment out the lines and roll my own `hex` dump but that means changing it every pull. 